### PR TITLE
fix(build): Fetch the latest triggred baseline jobs weburl

### DIFF
--- a/handler/build.go
+++ b/handler/build.go
@@ -561,11 +561,17 @@ func jobURLGenerator(id int, project string) string {
 	return generatedURL
 }
 
+// Generate joburl of baseline stage
 func getBaselineJobWebURL(data BuildJobs) string {
+	var maxJobID = 0
+	var jobURL string
 	for _, value := range data {
 		if value.Stage == "baseline" {
-			return value.WebURL
+			if value.ID > maxJobID {
+				maxJobID = value.ID
+				jobURL = value.WebURL
+			}
 		}
 	}
-	return ""
+	return jobURL
 }


### PR DESCRIPTION
This commit will fix following:
- If baseline job is triggered more than one times then it will fetch the latest triggered baseline job for getting the triggered id of different platform

Signed-off-by: Chandan Kumar <chandan.kumar@mayadata.io>