### PR TITLE
Fix index out of range issue

### DIFF
--- a/handler/openshift_commit.go
+++ b/handler/openshift_commit.go
@@ -196,11 +196,14 @@ func getReleaseTag(jobsData Jobs, token string) (string, error) {
 	// Run and get the output of grep.
 	value, _ := grep.Output()
 	result := strings.Split(string(value), "\n")
-	result = strings.Split(result[1], ":")
-	if result[1] == "" {
-		return "NA", nil
+	if result != nil {
+		if result[1] == "" {
+			return "NA", nil
+		}
+		result = strings.Split(result[1], ":")
+		return result[1], nil
 	}
-	return result[1], nil
+	return "NA", nil
 }
 
 // QueryReleasePipelineData fetches the builddashboard data from the db


### PR DESCRIPTION
Signed-off-by: chandan kumar <chandan.kumar@mayadata.io>

Issue fixed:
```
panic: runtime error: index out of range

goroutine 42 [running]:
github.com/mayadata-io/ci-e2e-status/handler.getReleaseTag(0xc000154000, 0x2d, 0x3f, 0xc00001c026, 0x15, 0x0, 0x0, 0x0, 0x0)
        /go/src/github.com/mayadata-io/ci-e2e-status/handler/openshift_commit.go:199 +0x794
github.com/mayadata-io/ci-e2e-status/handler.openshiftCommit(0xc00001c026, 0x15, 0x784608, 0xd, 0x784c50, 0xe, 0x7878e4, 0x15, 0x785e0b, 0x11)
        /go/src/github.com/mayadata-io/ci-e2e-status/handler/openshift_commit.go:42 +0xdd7
created by github.com/mayadata-io/ci-e2e-status/handler.UpdateDatabase
        /go/src/github.com/mayadata-io/ci-e2e-status/handler/updatedatabase.go:25 +0x18a
```