### PR TITLE
fix : display jobs more than 50 for pipeline

### DIFF
--- a/handler/konvoy.go
+++ b/handler/konvoy.go
@@ -211,7 +211,7 @@ func konvoyPipelineJobs(pipelineID int, token string) (Jobs, error) {
 	if pipelineID == 0 {
 		return nil, nil
 	}
-	url := BaseURL + "api/v4/projects/" + KONVOYID + "/pipelines/" + strconv.Itoa(pipelineID) + "/jobs?per_page=50"
+	url := BaseURL + "api/v4/projects/" + KONVOYID + "/pipelines/" + strconv.Itoa(pipelineID) + "/jobs?per_page=100"
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/handler/packet.go
+++ b/handler/packet.go
@@ -183,7 +183,7 @@ func packetPipelineJobs(pipelineID int, token string) (Jobs, error) {
 	if pipelineID == 0 {
 		return nil, nil
 	}
-	url := BaseURL + "api/v4/projects/" + PACKETID + "/pipelines/" + strconv.Itoa(pipelineID) + "/jobs?per_page=50"
+	url := BaseURL + "api/v4/projects/" + PACKETID + "/pipelines/" + strconv.Itoa(pipelineID) + "/jobs?per_page=100"
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
previously gitlab jobs not visible if more than 50 , ! now it is fixed by increasing page content to 100 .

Signed-off-by: bhaskarhc <hcbhaskar7@gmail.com>