### PR TITLE
fix[image_tag]: update cstor-csi releasetag job for openshift pipeline

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -24,7 +24,7 @@
                 },
                 {
                     "name": "openebs-cstor-csi",
-                    "releaseTagJob": "AAO9-CSTOR-OPERATOR"
+                    "releaseTagJob": "2ICO01-CSTOR-OPERATOR"
                 },
                 {
                     "name": "openebs-cstor",


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Due to the recent changes Made in the openshiuft cstor-csi pipelines release tag updates are not happening this PR fixes the issue while update the image tag 